### PR TITLE
ENG-787 now propagating spec.parameters correctly

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.entando</groupId>
         <artifactId>entando-quarkus-parent</artifactId>
-        <version>6.1.6</version>
+        <version>6.1.7</version>
     </parent>
     <version>6.1.0-SNAPSHOT</version>
     <artifactId>entando-k8s-plugin-controller</artifactId>

--- a/src/main/java/org/entando/kubernetes/controller/plugin/EntandoPluginDeployableContainer.java
+++ b/src/main/java/org/entando/kubernetes/controller/plugin/EntandoPluginDeployableContainer.java
@@ -28,13 +28,15 @@ import org.entando.kubernetes.controller.KubeUtils;
 import org.entando.kubernetes.controller.creators.DeploymentCreator;
 import org.entando.kubernetes.controller.database.DatabaseSchemaCreationResult;
 import org.entando.kubernetes.controller.spi.DatabasePopulator;
+import org.entando.kubernetes.controller.spi.ParameterizableContainer;
 import org.entando.kubernetes.controller.spi.PersistentVolumeAware;
 import org.entando.kubernetes.controller.spi.SpringBootDeployableContainer;
 import org.entando.kubernetes.model.DbmsVendor;
+import org.entando.kubernetes.model.EntandoDeploymentSpec;
 import org.entando.kubernetes.model.plugin.EntandoPlugin;
 import org.entando.kubernetes.model.plugin.PluginSecurityLevel;
 
-public class EntandoPluginDeployableContainer implements PersistentVolumeAware, SpringBootDeployableContainer {
+public class EntandoPluginDeployableContainer implements PersistentVolumeAware, SpringBootDeployableContainer, ParameterizableContainer {
 
     public static final String PLUGINDB = "plugindb";
     private final EntandoPlugin entandoPlugin;
@@ -135,5 +137,10 @@ public class EntandoPluginDeployableContainer implements PersistentVolumeAware, 
     public Optional<DatabasePopulator> useDatabaseSchemas(Map<String, DatabaseSchemaCreationResult> dbSchemas) {
         this.dbSchemas = dbSchemas;
         return Optional.empty();
+    }
+
+    @Override
+    public EntandoDeploymentSpec getCustomResourceSpec() {
+        return entandoPlugin.getSpec();
     }
 }

--- a/src/main/java/org/entando/kubernetes/controller/plugin/EntandoPluginSidecarDeployableContainer.java
+++ b/src/main/java/org/entando/kubernetes/controller/plugin/EntandoPluginSidecarDeployableContainer.java
@@ -26,10 +26,12 @@ import org.entando.kubernetes.controller.KubeUtils;
 import org.entando.kubernetes.controller.spi.DeployableContainer;
 import org.entando.kubernetes.controller.spi.KeycloakAware;
 import org.entando.kubernetes.controller.spi.KubernetesPermission;
+import org.entando.kubernetes.controller.spi.ParameterizableContainer;
 import org.entando.kubernetes.controller.spi.TlsAware;
+import org.entando.kubernetes.model.EntandoDeploymentSpec;
 import org.entando.kubernetes.model.plugin.EntandoPlugin;
 
-public class EntandoPluginSidecarDeployableContainer implements DeployableContainer, KeycloakAware, TlsAware {
+public class EntandoPluginSidecarDeployableContainer implements DeployableContainer, KeycloakAware, TlsAware, ParameterizableContainer {
 
     public static final String REQUIRED_ROLE = "connection-config";
     private static final String ENTANDO_PLUGIN_SIDECAR_IMAGE = "entando/entando-plugin-sidecar";
@@ -102,4 +104,8 @@ public class EntandoPluginSidecarDeployableContainer implements DeployableContai
                 new KubernetesPermission("", "secrets", "create", "get", "update", "delete"));
     }
 
+    @Override
+    public EntandoDeploymentSpec getCustomResourceSpec() {
+        return entandoPlugin.getSpec();
+    }
 }

--- a/src/test/java/org/entando/kubernetes/controller/plugin/inprocesstests/DeployPluginTest.java
+++ b/src/test/java/org/entando/kubernetes/controller/plugin/inprocesstests/DeployPluginTest.java
@@ -46,6 +46,7 @@ import io.fabric8.kubernetes.api.model.rbac.RoleBinding;
 import io.fabric8.kubernetes.client.Watcher.Action;
 import io.quarkus.runtime.StartupEvent;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.Map;
 import org.entando.kubernetes.controller.EntandoOperatorConfigProperty;
 import org.entando.kubernetes.controller.KeycloakClientConfig;
@@ -101,8 +102,11 @@ public class DeployPluginTest implements InProcessTestUtil, FluentTraversals, Va
     private static final int PORT_3396 = 3306;
     private static final int PORT_8081 = 8081;
     private static final int PORT_8083 = 8083;
+    public static final String PARAMETER_NAME = "MY_PARAM";
+    public static final String PARAMETER_VALUE = "MY_VALUE";
     final EntandoPlugin entandoPlugin = new EntandoPluginBuilder(buildTestEntandoPlugin()).editSpec()
-            .withSecurityLevel(PluginSecurityLevel.LENIENT).endSpec().build();
+            .withParameters(Collections.singletonMap(PARAMETER_NAME, PARAMETER_VALUE)).withSecurityLevel(PluginSecurityLevel.LENIENT).endSpec().build();
+
     @Spy
     private final SimpleK8SClient<EntandoResourceClientDouble> client = new SimpleK8SClientDouble();
     @Mock
@@ -372,6 +376,7 @@ public class DeployPluginTest implements InProcessTestUtil, FluentTraversals, Va
                 is(KubeUtils.USERNAME_KEY));
         assertThat(theVariableReferenceNamed(SPRING_DATASOURCE_PASSWORD).on(thePluginContainer).getSecretKeyRef().getKey(),
                 is(KubeUtils.PASSSWORD_KEY));
+        assertThat(theVariableNamed(PARAMETER_NAME).on(thePluginContainer), is(PARAMETER_VALUE));
         assertThat(theVariableNamed("SPRING_DATASOURCE_URL").on(thePluginContainer),
                 is("jdbc:mysql://" + MY_PLUGIN_DB_SERVICE + "." + MY_PLUGIN_NAMESPACE + ".svc.cluster.local:3306/my_plugin_plugindb"));
         assertThat(theVariableNamed("ENTANDO_CONNECTIONS_ROOT").on(thePluginContainer),

--- a/src/test/java/org/entando/kubernetes/controller/plugin/inprocesstests/DeployPluginTest.java
+++ b/src/test/java/org/entando/kubernetes/controller/plugin/inprocesstests/DeployPluginTest.java
@@ -105,7 +105,8 @@ public class DeployPluginTest implements InProcessTestUtil, FluentTraversals, Va
     public static final String PARAMETER_NAME = "MY_PARAM";
     public static final String PARAMETER_VALUE = "MY_VALUE";
     final EntandoPlugin entandoPlugin = new EntandoPluginBuilder(buildTestEntandoPlugin()).editSpec()
-            .withParameters(Collections.singletonMap(PARAMETER_NAME, PARAMETER_VALUE)).withSecurityLevel(PluginSecurityLevel.LENIENT).endSpec().build();
+            .withParameters(Collections.singletonMap(PARAMETER_NAME, PARAMETER_VALUE))
+            .withSecurityLevel(PluginSecurityLevel.LENIENT).endSpec().build();
 
     @Spy
     private final SimpleK8SClient<EntandoResourceClientDouble> client = new SimpleK8SClientDouble();


### PR DESCRIPTION
Currently the spec.parameters don't get propagated to all containers. This PR ensures that all containers can now receive environment variables from spec.parameters