### PR TITLE
ENG-3515 use networking.k8s.io/v1 api group instead of extensions/v1beta1 for the created ingresses

### DIFF
--- a/Dockerfile.jvm
+++ b/Dockerfile.jvm
@@ -1,5 +1,5 @@
 #FROM entando/entando-ubi8-java11-base:6.3.1
-FROM entando/entando-k8s-operator-common:6.3.19
+FROM entando/entando-k8s-operator-common:6.5.0-ENG-3515-PR-104
 ARG VERSION
 LABEL name="Entando K8S Plugin Controller" \
       vendor="Entando" \

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.entando</groupId>
         <artifactId>entando-quarkus-parent</artifactId>
-        <version>6.3.18</version>
+        <version>6.5.0-ENG-3515-PR-26</version>
         <relativePath/>
     </parent>
     <version>6.5.0</version>
@@ -64,7 +64,7 @@
     <properties>
         <github.organization>entando-k8s</github.organization>
         <sonar.projectKey>${github.organization}_${project.artifactId}</sonar.projectKey>
-        <entando-k8s-operator-common.version>6.3.19</entando-k8s-operator-common.version>
+        <entando-k8s-operator-common.version>6.5.0-ENG-3515-PR-104</entando-k8s-operator-common.version>
         <preDeploymentTestGroups>pre-deployment</preDeploymentTestGroups>
         <postDeploymentTestGroups>post-deployment</postDeploymentTestGroups>
     </properties>

--- a/src/main/java/org/entando/kubernetes/controller/plugin/EntandoPluginDeploymentResult.java
+++ b/src/main/java/org/entando/kubernetes/controller/plugin/EntandoPluginDeploymentResult.java
@@ -18,7 +18,7 @@ package org.entando.kubernetes.controller.plugin;
 
 import io.fabric8.kubernetes.api.model.Pod;
 import io.fabric8.kubernetes.api.model.Service;
-import io.fabric8.kubernetes.api.model.extensions.Ingress;
+import io.fabric8.kubernetes.api.model.networking.v1.Ingress;
 import org.entando.kubernetes.controller.spi.result.ExposedDeploymentResult;
 
 public class EntandoPluginDeploymentResult extends ExposedDeploymentResult<EntandoPluginDeploymentResult> {

--- a/src/main/java/org/entando/kubernetes/controller/plugin/EntandoPluginServerDeployable.java
+++ b/src/main/java/org/entando/kubernetes/controller/plugin/EntandoPluginServerDeployable.java
@@ -19,7 +19,7 @@ package org.entando.kubernetes.controller.plugin;
 import io.fabric8.kubernetes.api.model.Pod;
 import io.fabric8.kubernetes.api.model.Service;
 import io.fabric8.kubernetes.api.model.apps.Deployment;
-import io.fabric8.kubernetes.api.model.extensions.Ingress;
+import io.fabric8.kubernetes.api.model.networking.v1.Ingress;
 import java.util.ArrayList;
 import java.util.List;
 import org.entando.kubernetes.controller.spi.common.EntandoOperatorComplianceMode;


### PR DESCRIPTION
…eta1 for the created ingresses